### PR TITLE
chore: prevent package manager conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Package manager conflicts - using pnpm
+package-lock.json
+yarn.lock
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 


### PR DESCRIPTION
- Add package-lock.json and yarn.lock to .gitignore
- Ensures only pnpm-lock.yaml is tracked
- Prevents future merge conflicts between package managers